### PR TITLE
Multiple identity support

### DIFF
--- a/src/flash.c
+++ b/src/flash.c
@@ -74,6 +74,13 @@ static uint8_t *last_p;
 const uint8_t flash_data[4] __attribute__ ((section (".gnuk_data"))) = {
   0x00, 0x00, 0xff, 0xff
 };
+const uint8_t flash_data1[4] __attribute__ ((section (".gnuk_data1"))) = {
+  0x00, 0x00, 0xff, 0xff
+};
+const uint8_t flash_data2[4] __attribute__ ((section (".gnuk_data2"))) = {
+  0x00, 0x00, 0xff, 0xff
+};
+
 
 #ifdef GNU_LINUX_EMULATION
 extern uint8_t *flash_addr_key_storage_start;
@@ -84,8 +91,16 @@ extern uint8_t *flash_addr_data_storage_start;
 /* Linker sets these symbols */
 extern uint8_t _keystore_pool;
 extern uint8_t _data_pool;
-#define FLASH_ADDR_KEY_STORAGE_START  ((&_keystore_pool))
-#define FLASH_ADDR_DATA_STORAGE_START ((&_data_pool))
+extern uint8_t _keystore_pool1;
+extern uint8_t _data_pool1;
+extern uint8_t _keystore_pool2;
+extern uint8_t _data_pool2;
+static uint8_t *_keystore_map[]={(&_keystore_pool),(&_keystore_pool1),(&_keystore_pool2)};
+static uint8_t *_data_map[]={(&_data_pool),(&_data_pool1),(&_data_pool2)};
+static uint8_t _selected_identity=0;
+
+#define FLASH_ADDR_KEY_STORAGE_START  (_keystore_map[_selected_identity])
+#define FLASH_ADDR_DATA_STORAGE_START (_data_map[_selected_identity])
 #endif
 
 static int key_available_at (const uint8_t *k, int key_size)

--- a/src/flash.c
+++ b/src/flash.c
@@ -95,13 +95,25 @@ extern uint8_t _keystore_pool1;
 extern uint8_t _data_pool1;
 extern uint8_t _keystore_pool2;
 extern uint8_t _data_pool2;
+extern uint8_t _identsel; /* identity selection page */
+extern uint8_t ch_certificate_start;
+extern uint8_t ch_certificate_start1;
+extern uint8_t ch_certificate_start2; /*identity2 can only store one page size worth of cert do*/
+static uint8_t *_ch_cert_map[]={(&ch_certificate_start),(&ch_certificate_start1),(&ch_certificate_start2)};
+
+
 static uint8_t *_keystore_map[]={(&_keystore_pool),(&_keystore_pool1),(&_keystore_pool2)};
 static uint8_t *_data_map[]={(&_data_pool),(&_data_pool1),(&_data_pool2)};
-static uint8_t _selected_identity=0;
+uint8_t _selected_identity=0;
 
 #define FLASH_ADDR_KEY_STORAGE_START  (_keystore_map[_selected_identity])
 #define FLASH_ADDR_DATA_STORAGE_START (_data_map[_selected_identity])
+#define FLASH_ADDR_CHCERT_START (_ch_cert_map[_selected_identity])
 #endif
+
+uint8_t* flash_get_ch_cert_start(){
+    return FLASH_ADDR_CHCERT_START;
+}
 
 static int key_available_at (const uint8_t *k, int key_size)
 {
@@ -120,6 +132,104 @@ static int key_available_at (const uint8_t *k, int key_size)
     return 0;
 
   return 1;
+}
+
+/*Identity selection algorithm:
+ * For every even byte in identity selection page
+ * If last two bits of byte are zero, skip to next even byte
+ * Otherwise, interpet as follows:
+ * last two bits are 01 -> identity 1; 10-> identity 2; 11-> identity 0 
+ * If all bytes in the page are zero, erase the page, treat as identity 0.
+ * To change identity:
+ * If changing from identity 0 to identity 1 or 2
+ *   Find the current identity byte (first nonzero even byte)
+ *   Write the current identity to its address
+ * If changing from identity 1 or 2 to any other identity
+ *   Find the current identity byte
+ *   If it it the last byte on the page:
+ *      - erase the page
+ *      - if the desired identity is 1 or 2, write the desired identity to byte 0 of the page
+ *   Otherwise:
+ *      - write a zero to its address
+ *      - if the desired identity is 1 or 2, increment the address by 2 and write the desired identity there
+ * 
+ * Why this works:
+ * Flash gets initialized in an all-ones state after erase. Flash writes can clear bits but not set them without an erase.
+ * The STM32F1 flash controller however has a bug that only allows writing two bytes at a time.
+ * It will also flip the order of the bytes we write (0xAABB gets recorded as 0xBBAA).
+ * The permitted writes are: 0xffff -> any value; any value-> 0x0000.
+ * We aim to minimize the number of erases. Here's an example. Imagine we have 6 bytes:
+ * Flash state: 0xff ff ff ff ff ff
+ * We start out with identity 0, because the byte [0] ends in 11:
+ * 0xff = 1111 1111
+ * We change identity from 0 to 1 by writing 0x0001 to address 0:
+ * 0xff ff ff ff ff ff -> 0x01 00 ff ff ff ff (bytes get flipped, that's ok)
+ * Now, let's say we want to change identity back to 0. We write 0x0000 to address 0: 
+ * 0x01 00 ff ff ff ff -> 0x00 00 ff ff ff ff (first nonzero even byte is now address 2, it reads as identity 0)
+ * We change identity again, this time from 0 to 2 (write 0x0002 to address 2):
+ * 0x00 00 ff ff ff ff -> 0x00 00 02 00 ff ff (first nonzero even byte is still address 2, it reads as identity 2)
+ * and from 2 to 1 (write 0x0000 to address 2, 0x0001 to address 4)
+ * 0x00 00 02 00 ff ff -> 0x00 00 00 00 01 00 (first nonzero even byte is now address 4, it reads as identity 1)
+ * On the next change, we'll run out of space - that's fine. Let's go from 1 to 0 again
+ * Because we are on the last byte, we erase the page
+ * 0xff ff ff ff ff ff (reads as identity 0)
+ * If, instead, we were changing from 1 to 2, we would also write 0x0002 to address 0
+ * Now, of course, instead of 6 bytes we have 1024 - meaning we need to erase even less often. This is great!
+ * On other stm32 parts (other than the F1 series) the flash controller allows clearing arbitrary bits. This would let us reduce erases even further.
+ */
+void flash_read_selected_identity(){
+    for(uint16_t byte=0;byte<1024;byte+=2){
+        uint8_t b=((&_identsel)[byte]&0x3);
+        if(b==0x00){
+            continue; /* skip all all-zero bytes */
+        }else{
+            if(b==3){ b=0; }
+            _selected_identity=b;
+            return;
+        }
+    }
+    /* default identity is zero - if we reached here and found only zeroes the flash page is in an invalid state and we should erase it */
+    flash_erase_page ((uintptr_t)(&_identsel));
+}
+
+
+static void flash_write_selected_identity(uint8_t id){
+    if(id>2){
+        return;
+    }
+    if(id==_selected_identity){
+        return;
+    }
+    for(uint16_t byte=0;byte<1024;byte+=2){
+        uint8_t b=((&_identsel)[byte]&0x3);
+        if(b==0x00){
+            continue; /* skip all all-zero byte pairs */
+        }else{
+            if(_selected_identity==0){
+                flash_program_halfword ((uintptr_t)((&_identsel)+byte),id);
+                return;
+            }else{
+                if(byte==1022){
+                    flash_erase_page ((uintptr_t)(&_identsel));
+                    if(id>0){
+                        flash_program_halfword ((uintptr_t)((&_identsel)),id);
+                    }
+                    return;
+                }else{
+                    flash_program_halfword ((uintptr_t)((&_identsel)+byte),0);
+                    if(id>0){
+                        flash_program_halfword ((uintptr_t)((&_identsel)+byte+2),id);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+void flash_set_identity(uint8_t id){
+    flash_write_selected_identity(id);
+    nvic_system_reset();
 }
 
 
@@ -185,9 +295,11 @@ flash_terminate (void)
   data_pool = FLASH_ADDR_DATA_STORAGE_START;
   last_p = FLASH_ADDR_DATA_STORAGE_START + FLASH_DATA_POOL_HEADER_SIZE;
 #if defined(CERTDO_SUPPORT)
-  flash_erase_page ((uintptr_t)&ch_certificate_start);
+  flash_erase_page ((uintptr_t)FLASH_ADDR_CHCERT_START);
+  if(_selected_identity!=2){
   if (FLASH_CH_CERTIFICATE_SIZE > flash_page_size)
-    flash_erase_page ((uintptr_t)(&ch_certificate_start + flash_page_size));
+    flash_erase_page ((uintptr_t)(FLASH_ADDR_CHCERT_START + flash_page_size));
+  }
 #endif
 }
 
@@ -697,12 +809,14 @@ flash_erase_binary (uint8_t file_id)
 {
   if (file_id == FILEID_CH_CERTIFICATE)
     {
-      const uint8_t *p = &ch_certificate_start;
+      const uint8_t *p = FLASH_ADDR_CHCERT_START;
       if (flash_check_blank (p, FLASH_CH_CERTIFICATE_SIZE) == 0)
 	{
 	  flash_erase_page ((uintptr_t)p);
-	  if (FLASH_CH_CERTIFICATE_SIZE > flash_page_size)
-	    flash_erase_page ((uintptr_t)p + flash_page_size);
+      if(_selected_identity!=2){
+	    if (FLASH_CH_CERTIFICATE_SIZE > flash_page_size)
+	      flash_erase_page ((uintptr_t)p + flash_page_size);
+      }
 	}
 
       return 0;
@@ -742,7 +856,10 @@ flash_write_binary (uint8_t file_id, const uint8_t *data,
   else if (file_id == FILEID_CH_CERTIFICATE)
     {
       maxsize = FLASH_CH_CERTIFICATE_SIZE;
-      p = &ch_certificate_start;
+      if(_selected_identity==2){
+          maxsize=flash_page_size;
+      }
+      p = FLASH_ADDR_CHCERT_START;
     }
 #endif
   else

--- a/src/gnuk.h
+++ b/src/gnuk.h
@@ -153,6 +153,8 @@ void flash_set_data_pool_last (const uint8_t *p);
 void flash_clear_halfword (uintptr_t addr);
 void flash_increment_counter (uint8_t counter_tag_nr);
 void flash_reset_counter (uint8_t counter_tag_nr);
+void flash_read_selected_identity(void);
+void flash_set_identity(uint8_t id);
 
 #define FILEID_SERIAL_NO	0
 #define FILEID_UPDATE_KEY_0	1
@@ -164,10 +166,11 @@ int flash_erase_binary (uint8_t file_id);
 int flash_write_binary (uint8_t file_id, const uint8_t *data,
 			uint16_t len, uint16_t offset);
 
-#define FLASH_CH_CERTIFICATE_SIZE 2048
+extern uint8_t _selected_identity;
+#define FLASH_CH_CERTIFICATE_SIZE (_selected_identity==2?1024:2048)
 
-/* Linker set these two symbols */
-extern uint8_t ch_certificate_start;
+/* Function to get currently selected ch_cert */
+uint8_t* flash_get_ch_cert_start(void);
 
 #define FIRMWARE_UPDATE_KEY_CONTENT_LEN 256	/* RSA-2048 (p and q) */
 

--- a/src/gnuk.ld.in
+++ b/src/gnuk.ld.in
@@ -128,6 +128,14 @@ SECTIONS
         LONG(0xffffffff);
         . += 1920;
         . = ALIGN (@FLASH_PAGE_SIZE@);
+        ch_certificate_start1 = .;
+        LONG(0xffffffff);
+        . += 1920;
+        . = ALIGN (@FLASH_PAGE_SIZE@);
+        ch_certificate_start2 = .;
+        LONG(0xffffffff);
+        . += 1020;
+        . = ALIGN (@FLASH_PAGE_SIZE@);
     } > flash =0xffffffff
 @CERTDO_SUPPORT_END@
 
@@ -156,9 +164,6 @@ SECTIONS
         . = ALIGN(@FLASH_PAGE_SIZE@);
         . += 1024;
         . = ALIGN(@FLASH_PAGE_SIZE@);
-        _updatekey_store1 = .;
-        . += 1024;
-        . = ALIGN(@FLASH_PAGE_SIZE@);
         _data_pool1 = .;
         KEEP(*(.gnuk_data1))
         . = ALIGN(@FLASH_PAGE_SIZE@);
@@ -169,9 +174,6 @@ SECTIONS
         . = ALIGN(@FLASH_PAGE_SIZE@);
         . += 1024;
         . = ALIGN(@FLASH_PAGE_SIZE@);
-        . += 1024;
-        . = ALIGN(@FLASH_PAGE_SIZE@);
-        _updatekey_store2 = .;
         . += 1024;
         . = ALIGN(@FLASH_PAGE_SIZE@);
         _data_pool2 = .;

--- a/src/gnuk.ld.in
+++ b/src/gnuk.ld.in
@@ -148,6 +148,40 @@ SECTIONS
         KEEP(*(.gnuk_data))
         . = ALIGN(@FLASH_PAGE_SIZE@);
         . += @FLASH_PAGE_SIZE@;
+        . = ALIGN (@FLASH_PAGE_SIZE@);
+        _keystore_pool1 = .;
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        _updatekey_store1 = .;
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        _data_pool1 = .;
+        KEEP(*(.gnuk_data1))
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += @FLASH_PAGE_SIZE@;
+        . = ALIGN (@FLASH_PAGE_SIZE@);
+        _keystore_pool2 = .;
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        _updatekey_store2 = .;
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        _data_pool2 = .;
+        KEEP(*(.gnuk_data2))
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        . += @FLASH_PAGE_SIZE@;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
+        _identsel = .;
+        . += 1024;
+        . = ALIGN(@FLASH_PAGE_SIZE@);
     } > flash =0xffffffff
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -309,6 +309,7 @@ main (int argc, const char *argv[])
 #endif
   chopstx_t ccid_thd;
   int wait_for_ack = 0;
+  flash_read_selected_identity();
 
   chopstx_conf_idle (1);
 

--- a/src/openpgp-do.c
+++ b/src/openpgp-do.c
@@ -666,7 +666,7 @@ do_openpgpcard_aid (uint16_t tag, int with_tag)
       *res_p++ = 0xff;
       *res_p++ = 0xfe;
 
-      *res_p++ = u[3];
+      *res_p++ = _selected_identity;
       *res_p++ = u[2];
       *res_p++ = u[1];
       *res_p++ = u[0];
@@ -2112,7 +2112,7 @@ gpg_do_get_data (uint16_t tag, int with_tag)
 #if defined(CERTDO_SUPPORT)
   if (tag == GPG_DO_CH_CERTIFICATE)
     {
-      apdu.res_apdu_data = &ch_certificate_start;
+      apdu.res_apdu_data = flash_get_ch_cert_start();
       apdu.res_apdu_data_len = ((apdu.res_apdu_data[2] << 8) | apdu.res_apdu_data[3]);
       if (apdu.res_apdu_data_len == 0xffff)
 	{

--- a/src/openpgp.c
+++ b/src/openpgp.c
@@ -54,6 +54,7 @@ static struct eventflag *openpgp_comm;
 #define INS_PGP_GENERATE_ASYMMETRIC_KEY_PAIR	0x47
 #define INS_EXTERNAL_AUTHENTICATE		0x82
 #define INS_GET_CHALLENGE			0x84
+#define INS_SET_IDENTITY			0x85
 #define INS_INTERNAL_AUTHENTICATE		0x88
 #define INS_SELECT_FILE				0xa4
 #define INS_READ_BINARY				0xb0
@@ -806,7 +807,7 @@ cmd_read_binary (struct eventflag *ccid_comm)
       const uint8_t *p;
       uint16_t len = 256;
 
-      p = &ch_certificate_start;
+      p = flash_get_ch_cert_start();
       if (offset >= FLASH_CH_CERTIFICATE_SIZE)
 	GPG_MEMORY_FAILURE ();
       else
@@ -908,6 +909,24 @@ cmd_get_data (struct eventflag *ccid_comm)
 
   gpg_do_get_data (tag, 0);
 }
+
+static void
+cmd_set_identity (struct eventflag *ccid_comm)
+{
+  uint16_t tag = ((P1 (apdu)<<8) | P2 (apdu));
+
+  (void)ccid_comm;
+  DEBUG_INFO (" - Set Identity\r\n");
+
+  if(tag>2){
+      GPG_MEMORY_FAILURE ();
+      return;
+  }else{
+      GPG_SUCCESS ();
+      flash_set_identity(tag);
+  }
+}
+
 
 #define ECDSA_HASH_LEN 32
 #define ECDSA_SIGNATURE_LENGTH 64
@@ -1525,6 +1544,7 @@ const struct command cmds[] = {
     cmd_external_authenticate },
 #endif
   { INS_GET_CHALLENGE, cmd_get_challenge }, /* Not in OpenPGP card protocol */
+  { INS_SET_IDENTITY, cmd_set_identity }, /* Not in OpenPGP card protocol */
   { INS_INTERNAL_AUTHENTICATE, cmd_internal_authenticate },
   { INS_SELECT_FILE, cmd_select_file },
   { INS_READ_BINARY, cmd_read_binary },     /* Not in OpenPGP card protocol */

--- a/tool/gnuk_token.py
+++ b/tool/gnuk_token.py
@@ -326,6 +326,15 @@ class gnuk_token(object):
             raise ValueError("%02x%02x" % (sw[0], sw[1]))
         return self.cmd_get_response(sw[1])
 
+    def cmd_set_identity(self, ident):
+        cmd_data = iso7816_compose(0x85, 0x00, ident, b"")
+        sw = self.icc_send_cmd(cmd_data)
+        if len(sw) != 2:
+            raise ValueError(sw)
+        if not (sw[0] == 0x90 and sw[1] == 0x00):
+            raise ValueError("%02x%02x" % (sw[0], sw[1]))
+        return True
+
     def cmd_change_reference_data(self, who, data):
         cmd_data = iso7816_compose(0x24, 0x00, 0x80+who, data)
         sw = self.icc_send_cmd(cmd_data)

--- a/tool/set_identity.py
+++ b/tool/set_identity.py
@@ -1,0 +1,45 @@
+#! /usr/bin/python3
+
+from collections import defaultdict
+from subprocess import check_output
+
+from gnuk_token import get_gnuk_device, gnuk_devices_by_vidpid, \
+    gnuk_token, regnual, SHA256_OID_PREFIX, crc32, parse_kdf_data
+from kdf_calc import kdf_calc
+from usb.core import USBError
+
+import sys, binascii, time, os
+import rsa
+from struct import pack
+
+if __name__=="__main__":
+    if len(sys.argv)!=2:
+        print("missing identity number")
+        sys.exit(1)
+    if not sys.argv[1].isdigit():
+        print("identity number must be a digit")
+        sys.exit(1)
+    identity=int(sys.argv[1])
+    if(identity<0 or identity>2):
+        print("identity must be 0, 1 or 2")
+        sys.exit(1)
+    print("Trying to set identity to %d"%(identity,))
+    for x in range(3):
+        try:
+            gnuk = get_gnuk_device()
+            gnuk.cmd_select_openpgp()
+            try:
+                gnuk.cmd_set_identity(identity)
+            except USBError:
+                print("device has reset, and should now have the new identity")
+                sys.exit(0);
+                
+        except ValueError as e:
+            if 'No ICC present' in str(e):
+                print("Could not connect to device, trying to close scdaemon")
+                result = check_output(["gpg-connect-agent",
+                                           "SCD KILLSCD", "SCD BYE", "/bye"])
+                time.sleep(3)
+            else:
+                print('*** Found error: {}'.format(str(e)))
+    


### PR DESCRIPTION
This PR implements multiple identity support for the NK Start. Identities are changed with ccid command 0x85 (or tool/set_identity.py). The card serial number is different for each identity, each identity has its own keys, data objects, and cert-DOs. All identities are identical in functionality, with the exception of identity 2, where the cert-DO is limited in size to 1 page (1kb) rather than 2kb like in identities 0 and 1. Factory reset currently resets the current identity only. The firmware update key is global to all identities. Changing identity resets the device and causes a USB re-enumeration.