### PR TITLE
HID identity switch capability

### DIFF
--- a/src/flash.c
+++ b/src/flash.c
@@ -228,6 +228,12 @@ static void flash_write_selected_identity(uint8_t id){
 }
 
 void flash_set_identity(uint8_t id){
+    if(id>2){
+        return;
+    }
+    if(id==_selected_identity){
+        return;
+    }
     flash_write_selected_identity(id);
     nvic_system_reset();
 }

--- a/src/usb_desc.c
+++ b/src/usb_desc.c
@@ -341,7 +341,7 @@ static const struct desc string_descriptors[] = {
   {gnuk_string_product, sizeof (gnuk_string_product)},
   {gnuk_string_serial, sizeof (gnuk_string_serial)},
   {gnuk_revision_detail, sizeof (gnuk_revision_detail)},
-  {gnuk_config_options, sizeof (gnuk_config_options)},
+  /*{gnuk_config_options, sizeof (gnuk_config_options)},*/
   {sys_version, sizeof (sys_version)},
 };
 #define NUM_STRING_DESC (sizeof (string_descriptors) / sizeof (struct desc))

--- a/tool/set_identity.py
+++ b/tool/set_identity.py
@@ -12,16 +12,24 @@ import sys, binascii, time, os
 import rsa
 from struct import pack
 
+def usage():
+    print("Usage: \npython3 set_identity.py id")
+    print("id must be 0, 1, or 2")
+
 if __name__=="__main__":
+    print("set_identity.py selects identity on a nitrokey start")
     if len(sys.argv)!=2:
         print("missing identity number")
+        usage();
         sys.exit(1)
     if not sys.argv[1].isdigit():
         print("identity number must be a digit")
+        usage();
         sys.exit(1)
     identity=int(sys.argv[1])
     if(identity<0 or identity>2):
         print("identity must be 0, 1 or 2")
+        usage();
         sys.exit(1)
     print("Trying to set identity to %d"%(identity,))
     for x in range(3):

--- a/tool/set_identity_hid.py
+++ b/tool/set_identity_hid.py
@@ -1,0 +1,46 @@
+#! /usr/bin/python3
+
+import hid, sys
+
+"""
+using hid library for this (with hidapi as backend) because it works
+even when OS HID driver has claimed the device.
+"""
+
+vid=0x20a0
+pid=0x4211
+
+def usage():
+    print("Usage: \npython3 set_identity_hid.py id")
+    print("id must be 0, 1, or 2")
+
+if __name__=="__main__":
+    print("set_identity_hid.py selects identity on a nitrokey start")
+    if len(sys.argv)!=2:
+        print("missing identity number")
+        usage();
+        sys.exit(1)
+    if not sys.argv[1].isdigit():
+        print("identity number must be a digit")
+        usage();
+        sys.exit(1)
+    identity=int(sys.argv[1])
+    if(identity<0 or identity>2):
+        print("identity must be 0, 1 or 2")
+        usage();
+        sys.exit(1)
+    print("Trying to set identity to %d"%(identity,))
+    try:
+        print("Attempting to acquire HID device")
+        h=hid.Device(vid,pid)
+        try:
+            print("Don't worry if you get a broken pipe error on the next line")
+            h.send_feature_report(bytes([0x10+identity,0x00]))
+            #We need the report length to be at least one byte, thus the 0x00
+            #The 0x10+identity is the report ID - report IDs 0x10,0x11, and 0x12 set identity
+        except:
+            #this call will fail, but identity will still be set
+            print("Device should now restart into new identity %d"%(identity))
+            pass
+    except:
+        print("Could not get device")


### PR DESCRIPTION
This pull request enables identity switching via the HID interface.
The identity switch happens when the host sends a set report command with a particular report id. Id 0x10 sets identity 0, 0x11 sets identity 1 and 0x12 sets identity 2.
The report must contain at least one byte (nonzero length).
An example script to change identity using pyhidapi is included.