### PR TITLE
Reenable config string, but replace it with placeholder

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -356,6 +356,7 @@ else
   MEMORY_SIZE=20
   CONFIG="common:debug=$debug:pinpad=$pinpad:certdo=$certdo:factory_reset=$factory_reset"
 fi
+PLACEHOLDER_CONFIG="*:*"
 
 output_vid_pid_version () {
   echo "$VIDPID" | \
@@ -428,10 +429,10 @@ output_vendor_product_serial_strings () {
   echo '};'
   echo
   echo "static const uint8_t ${name}config_options[] = {"
-  echo "  ${#CONFIG}*2+2,                       /* bLength */"
+  echo "  ${#PLACEHOLDER_CONFIG}*2+2,                       /* bLength */"
   echo "  STRING_DESCRIPTOR,            /* bDescriptorType */"
-  echo "  /* configure options: \"$CONFIG\" */"
-  echo $CONFIG | sed -e "s/\(........\)/\1\\${nl}/g" | sed -n -e "s/\(.\)/'\1', 0, /g" -e "s/^/  /" -e "/^  ./s/ $//p"
+  echo "  /* configure options: \"$PLACEHOLDER_CONFIG\" */"
+  echo $PLACEHOLDER_CONFIG | sed -e "s/\(........\)/\1\\${nl}/g" | sed -n -e "s/\(.\)/'\1', 0, /g" -e "s/^/  /" -e "/^  ./s/ $//p"
   echo '};'
   echo '#endif'
   fi

--- a/src/usb_desc.c
+++ b/src/usb_desc.c
@@ -341,7 +341,7 @@ static const struct desc string_descriptors[] = {
   {gnuk_string_product, sizeof (gnuk_string_product)},
   {gnuk_string_serial, sizeof (gnuk_string_serial)},
   {gnuk_revision_detail, sizeof (gnuk_revision_detail)},
-  /*{gnuk_config_options, sizeof (gnuk_config_options)},*/
+  {gnuk_config_options, sizeof (gnuk_config_options)},
   {sys_version, sizeof (sys_version)},
 };
 #define NUM_STRING_DESC (sizeof (string_descriptors) / sizeof (struct desc))


### PR DESCRIPTION
Change the configure script to have a placeholder "*:*" as config string. Add config string back to binary.