### PR TITLE
Fix warnings with with arm-none-eabi-gcc 9.8.2

### DIFF
--- a/regnual/regnual.c
+++ b/regnual/regnual.c
@@ -30,7 +30,7 @@
 #include "usb_lld.h"
 #include "sys.h"
 
-extern void *memset (void *s, int c, size_t n);
+extern void *memset (void *s, int c, unsigned int n);
 
 extern void set_led (int);
 extern int flash_write (uint32_t dst_addr, const uint8_t *src, size_t len);

--- a/src/bn.c
+++ b/src/bn.c
@@ -425,3 +425,13 @@ bn256_random (bn256 *X)
     }
 }
 #endif
+
+void bn256_copy_if (int do_it, bn256 *dest, bn256 *src)
+{
+	volatile bn256 fake_dest;
+
+	if (do_it)
+		*dest = *src;
+	else
+		fake_dest = *src;
+}

--- a/src/bn.h
+++ b/src/bn.h
@@ -21,3 +21,7 @@ int bn256_is_even (const bn256 *X);
 int bn256_is_ge (const bn256 *A, const bn256 *B);
 int bn256_cmp (const bn256 *A, const bn256 *B);
 void bn256_random (bn256 *X);
+
+// Copy src into dest if do_it is true, otherwise copy
+// dest into a stack buffer so that it takes roughly constant time
+void bn256_copy_if (int do_it, bn256 *dest, bn256 *src);

--- a/src/gnuk.h
+++ b/src/gnuk.h
@@ -478,6 +478,6 @@ int pinpad_getline (int msg_code, uint32_t timeout_usec);
 #endif
 
 
-extern uint8_t _regnual_start, __heap_end__[];
+extern uint8_t _regnual_start[], __heap_end__[];
 
 uint8_t * sram_address (uint32_t offset);

--- a/src/main.c
+++ b/src/main.c
@@ -471,8 +471,8 @@ main (int argc, const char *argv[])
 
 #ifdef FLASH_UPGRADE_SUPPORT
   /* Set vector */
-  SCB->VTOR = (uintptr_t)&_regnual_start;
-  entry = calculate_regnual_entry_address (&_regnual_start);
+  SCB->VTOR = (uintptr_t)_regnual_start;
+  entry = calculate_regnual_entry_address (_regnual_start);
 #ifdef DFU_SUPPORT
   {
     /* Use SYS at ORIGIN_REAL instead of the one at ORIGIN */

--- a/src/modp256k1.c
+++ b/src/modp256k1.c
@@ -76,7 +76,7 @@ modp256k1_add (bn256 *X, const bn256 *A, const bn256 *B)
   cond &= bn256_sub (tmp, X, P256K1);
   if (cond)
     /* No-carry AND borrow */
-    memcpy (tmp, tmp, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
   else
     memcpy (X, tmp, sizeof (bn256));
 }
@@ -95,7 +95,7 @@ modp256k1_sub (bn256 *X, const bn256 *A, const bn256 *B)
   if (borrow)
     memcpy (X, tmp, sizeof (bn256));
   else
-    memcpy (tmp, tmp, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
 }
 
 /**

--- a/src/modp256k1.c
+++ b/src/modp256k1.c
@@ -74,11 +74,7 @@ modp256k1_add (bn256 *X, const bn256 *A, const bn256 *B)
 
   cond = (bn256_add (X, A, B) == 0);
   cond &= bn256_sub (tmp, X, P256K1);
-  if (cond)
-    /* No-carry AND borrow */
-    memcpy (tmp, X, sizeof (bn256)); // constant time
-  else
-    memcpy (X, tmp, sizeof (bn256));
+  bn256_copy_if (!cond, X, tmp);
 }
 
 /**
@@ -92,10 +88,7 @@ modp256k1_sub (bn256 *X, const bn256 *A, const bn256 *B)
 
   borrow = bn256_sub (X, A, B);
   bn256_add (tmp, X, P256K1);
-  if (borrow)
-    memcpy (X, tmp, sizeof (bn256));
-  else
-    memcpy (tmp, X, sizeof (bn256)); // constant time
+  bn256_copy_if (borrow, X, tmp);
 }
 
 /**
@@ -243,10 +236,7 @@ modp256k1_reduce (bn256 *X, const bn512 *A)
   modp256k1_add (W0, W0, S);
 
   borrow = bn256_sub (tmp, W0, P256K1);
-  if (borrow)
-    memcpy (tmp, W0, sizeof (bn256));
-  else
-    memcpy (W0, tmp, sizeof (bn256));
+  bn256_copy_if (!borrow, W0, tmp);
 
 #undef W0
 #undef W1

--- a/src/modp256r1.c
+++ b/src/modp256r1.c
@@ -71,7 +71,7 @@ modp256r1_add (bn256 *X, const bn256 *A, const bn256 *B)
   cond &= bn256_sub (tmp, X, P256R1);
   if (cond)
     /* No-carry AND borrow */
-    memcpy (tmp, tmp, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
   else
     memcpy (X, tmp, sizeof (bn256));
 }
@@ -90,7 +90,7 @@ modp256r1_sub (bn256 *X, const bn256 *A, const bn256 *B)
   if (borrow)
     memcpy (X, tmp, sizeof (bn256));
   else
-    memcpy (tmp, tmp, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
 }
 
 /**
@@ -122,7 +122,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S1->word[0] = A->word[0];
   borrow = bn256_sub (tmp0, S1, P256R1);
   if (borrow)
-    memcpy (tmp0, tmp0, sizeof (bn256));
+    memcpy (tmp0, S1, sizeof (bn256)); // constant time
   else
     memcpy (S1, tmp0, sizeof (bn256));
   /* X = S1 */
@@ -166,7 +166,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S5->word[0] = A->word[9];
   borrow = bn256_sub (tmp0, S5, P256R1);
   if (borrow)
-    memcpy (tmp0, tmp0, sizeof (bn256));
+    memcpy (tmp0, S5, sizeof (bn256)); // constant time
   else
     memcpy (S5, tmp0, sizeof (bn256));
   /* X += S5 */
@@ -180,7 +180,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S6->word[0] = A->word[11];
   borrow = bn256_sub (tmp0, S6, P256R1);
   if (borrow)
-    memcpy (tmp0, tmp0, sizeof (bn256));
+    memcpy (tmp0, S6, sizeof (bn256)); // constant time
   else
     memcpy (S6, tmp0, sizeof (bn256));
   /* X -= S6 */
@@ -195,7 +195,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S7->word[0] = A->word[12];
   borrow = bn256_sub (tmp0, S7, P256R1);
   if (borrow)
-    memcpy (tmp0, tmp0, sizeof (bn256));
+    memcpy (tmp0, S7, sizeof (bn256)); // constant time
   else
     memcpy (S7, tmp0, sizeof (bn256));
   /* X -= S7 */
@@ -225,7 +225,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
 
   borrow = bn256_sub (tmp, X, P256R1);
   if (borrow)
-    memcpy (tmp, X, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
   else
     memcpy (X, tmp, sizeof (bn256));
 
@@ -293,7 +293,7 @@ modp256r1_shift (bn256 *X, const bn256 *A, int shift)
 
   borrow = bn256_sub (tmp, X, P256R1);
   if (borrow)
-    memcpy (tmp, X, sizeof (bn256));
+    memcpy (tmp, X, sizeof (bn256)); // constant time
   else
     memcpy (X, tmp, sizeof (bn256));
 #undef borrow

--- a/src/modp256r1.c
+++ b/src/modp256r1.c
@@ -69,11 +69,7 @@ modp256r1_add (bn256 *X, const bn256 *A, const bn256 *B)
 
   cond = (bn256_add (X, A, B) == 0);
   cond &= bn256_sub (tmp, X, P256R1);
-  if (cond)
-    /* No-carry AND borrow */
-    memcpy (tmp, X, sizeof (bn256)); // constant time
-  else
-    memcpy (X, tmp, sizeof (bn256));
+  bn256_copy_if (!cond, X, tmp);
 }
 
 /**
@@ -87,10 +83,7 @@ modp256r1_sub (bn256 *X, const bn256 *A, const bn256 *B)
 
   borrow = bn256_sub (X, A, B);
   bn256_add (tmp, X, P256R1);
-  if (borrow)
-    memcpy (X, tmp, sizeof (bn256));
-  else
-    memcpy (tmp, X, sizeof (bn256)); // constant time
+  bn256_copy_if (!borrow, X, tmp);
 }
 
 /**
@@ -121,10 +114,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S1->word[1] = A->word[1];
   S1->word[0] = A->word[0];
   borrow = bn256_sub (tmp0, S1, P256R1);
-  if (borrow)
-    memcpy (tmp0, S1, sizeof (bn256)); // constant time
-  else
-    memcpy (S1, tmp0, sizeof (bn256));
+  bn256_copy_if (!borrow, S1, tmp0);
   /* X = S1 */
 
   S2->word[7] = A->word[15];
@@ -165,10 +155,8 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S5->word[1] = A->word[10];
   S5->word[0] = A->word[9];
   borrow = bn256_sub (tmp0, S5, P256R1);
-  if (borrow)
-    memcpy (tmp0, S5, sizeof (bn256)); // constant time
-  else
-    memcpy (S5, tmp0, sizeof (bn256));
+  bn256_copy_if (!borrow, S5, tmp0);
+
   /* X += S5 */
   modp256r1_add (X, X, S5);
 
@@ -179,10 +167,8 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S6->word[1] = A->word[12];
   S6->word[0] = A->word[11];
   borrow = bn256_sub (tmp0, S6, P256R1);
-  if (borrow)
-    memcpy (tmp0, S6, sizeof (bn256)); // constant time
-  else
-    memcpy (S6, tmp0, sizeof (bn256));
+  bn256_copy_if (!borrow, S6, tmp0);
+
   /* X -= S6 */
   modp256r1_sub (X, X, S6);
 
@@ -194,10 +180,8 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   S7->word[1] = A->word[13];
   S7->word[0] = A->word[12];
   borrow = bn256_sub (tmp0, S7, P256R1);
-  if (borrow)
-    memcpy (tmp0, S7, sizeof (bn256)); // constant time
-  else
-    memcpy (S7, tmp0, sizeof (bn256));
+  bn256_copy_if (!borrow, S7, tmp0);
+
   /* X -= S7 */
   modp256r1_sub (X, X, S7);
 
@@ -224,10 +208,7 @@ modp256r1_reduce (bn256 *X, const bn512 *A)
   modp256r1_sub (X, X, S9);
 
   borrow = bn256_sub (tmp, X, P256R1);
-  if (borrow)
-    memcpy (tmp, X, sizeof (bn256)); // constant time
-  else
-    memcpy (X, tmp, sizeof (bn256));
+  bn256_copy_if (!borrow, X, tmp0);
 
 #undef S1
 #undef S2
@@ -292,9 +273,6 @@ modp256r1_shift (bn256 *X, const bn256 *A, int shift)
   modp256r1_sub (X, X, tmp);
 
   borrow = bn256_sub (tmp, X, P256R1);
-  if (borrow)
-    memcpy (tmp, X, sizeof (bn256)); // constant time
-  else
-    memcpy (X, tmp, sizeof (bn256));
+  bn256_copy_if (!borrow, X, tmp);
 #undef borrow
 }

--- a/src/openpgp.c
+++ b/src/openpgp.c
@@ -737,10 +737,10 @@ cmd_pgp_gakp (struct eventflag *ccid_comm)
 const uint8_t *
 gpg_get_firmware_update_key (uint8_t keyno)
 {
-  extern uint8_t _updatekey_store;
+  extern uint8_t _updatekey_store[];
   const uint8_t *p;
 
-  p = &_updatekey_store + keyno * FIRMWARE_UPDATE_KEY_CONTENT_LEN;
+  p = &_updatekey_store[keyno * FIRMWARE_UPDATE_KEY_CONTENT_LEN];
   return p;
 }
 #endif

--- a/src/usb_ctrl.c
+++ b/src/usb_ctrl.c
@@ -226,7 +226,7 @@ static const uint8_t lun_table[] = { 0, 0, 0, 0, };
 #endif
 
 #ifdef FLASH_UPGRADE_SUPPORT
-static const uint8_t *const mem_info[] = { &_regnual_start,  __heap_end__, };
+static const uint8_t *const mem_info[] = { _regnual_start,  __heap_end__, };
 #endif
 
 #define USB_FSIJ_GNUK_MEMINFO     0
@@ -244,7 +244,7 @@ download_check_crc32 (struct usb_dev *dev, const uint32_t *end_p)
 
   crc32_rv_reset ();
 
-  for (p = (const uint32_t *)&_regnual_start; p < end_p; p++)
+  for (p = (const uint32_t *)_regnual_start; p < end_p; p++)
     crc32_rv_step (rbit (*p));
 
   if ((rbit (crc32_rv_get ()) ^ crc32) == 0xffffffff)
@@ -283,7 +283,7 @@ usb_setup (struct usb_dev *dev)
 	      if (ccid_get_ccid_state () != CCID_STATE_EXITED)
 		return -1;
 
-	      if (addr < &_regnual_start || addr + arg->len > __heap_end__)
+	      if (addr < _regnual_start || addr + arg->len > __heap_end__)
 		return -1;
 
 	      if (arg->index + arg->len < 256)

--- a/tool/upgrade_by_passwd.py
+++ b/tool/upgrade_by_passwd.py
@@ -83,7 +83,7 @@ IS_LINUX = platform.system() == "Linux"
 
 
 def local_print(message: str = '', **kwargs):
-    if message and message is not '.':
+    if message and message != '.':
         logger.debug('print: {}'.format(message.strip()))
     print(message, **kwargs)
 
@@ -168,7 +168,7 @@ def main(wait_e, keyno, passwd, data_regnual, data_upgrade, skip_bootloader, ver
         local_print('*** Running update. Do NOT remove the device from the USB slot, until further notice.')
 
         local_print("Downloading flash upgrade program...")
-        gnuk.download(mem_info[0], data_regnual, progress_func=progress_func, verbose=verbosity is 2)
+        gnuk.download(mem_info[0], data_regnual, progress_func=progress_func, verbose=verbosity == 2)
         local_print("Run flash upgrade program...")
         gnuk.execute(mem_info[0] + len(data_regnual) - 4)
         #
@@ -206,7 +206,7 @@ def main(wait_e, keyno, passwd, data_regnual, data_upgrade, skip_bootloader, ver
     if verbosity:
         local_print("%08x:%08x" % mem_info)
     local_print("Downloading the program")
-    reg.download(mem_info[0], data_upgrade, progress_func=progress_func, verbose=verbosity is 2)
+    reg.download(mem_info[0], data_upgrade, progress_func=progress_func, verbose=verbosity == 2)
     local_print("Protecting device")
     reg.protect()
     local_print("Finish flashing")
@@ -391,7 +391,7 @@ def start():
     passwd = None
     wait_e = args.wait_e
 
-    if args.verbose is 3:
+    if args.verbose == 3:
         stream_handler = logging.StreamHandler()
         stream_handler.setLevel(logging.DEBUG)
         stream_handler.setFormatter(logging.Formatter(LOG_FORMAT_STDOUT))


### PR DESCRIPTION
This addresses the constant time `memcpy()` in #53 as well as a few other warnings produced by a recent arm-none-eabi-gcc.