### PR TITLE
Update upgrade_by_password.py command line

### DIFF
--- a/prebuilt/README.md
+++ b/prebuilt/README.md
@@ -68,7 +68,7 @@ Depending on you current firmware you have to choose the right prebuilts:
 
 Now we can proceed with the actual upgrade:
 ```
-./upgrade_by_passwd.py ../prebuilt/$RTM/regnual.bin ../prebuilt/$RTM/gnuk.bin
+./upgrade_by_passwd.py --regnual ../prebuilt/$RTM/regnual.bin --gnuk ../prebuilt/$RTM/gnuk.bin
 ```
 
 Please provide the admin-PIN of your NK Start and wait for the results. To check that firmware version was actually changed please run:


### PR DESCRIPTION
The current version of upgrade_by_passwd.py command line parser wants the --regnual and --gnuk options. Update the documentation accordingly.

usage: upgrade_by_passwd.py [-h] [--regnual REGNUAL] [--gnuk GNUK] [-f] [-p PASSWORD] [-e WAIT_E] [-k KEYNO] [-v VERBOSE] [-y] [-b]